### PR TITLE
19 establish growzone service

### DIFF
--- a/app/facades/grow_zone_facade.rb
+++ b/app/facades/grow_zone_facade.rb
@@ -1,0 +1,10 @@
+class GrowZoneFacade
+  def self.get_zone(zipcode)
+    json = GrowZoneService.get_zone(zipcode)
+    json_to_poro(json).zone
+  end
+
+  def self.json_to_poro(json)
+    GrowZone.new(json)
+  end
+end

--- a/app/poros/grow_zone.rb
+++ b/app/poros/grow_zone.rb
@@ -1,0 +1,7 @@
+class GrowZone
+  attr_reader :zone
+
+  def initialize(data)
+    @zone = data[:hardiness_zone]
+  end
+end

--- a/app/services/grow_zone_service.rb
+++ b/app/services/grow_zone_service.rb
@@ -7,7 +7,7 @@ class GrowZoneService
   def self.conn
     Faraday.new(
       url: 'https://plant-hardiness-zone.p.rapidapi.com',
-      headers: { 'X-RapidAPI-Key': ENV['X-RapidAPI-Key'] }
+      headers: { 'X-RapidAPI-Key': ENV['rapidAPI'] }
     )
   end
 

--- a/app/services/grow_zone_service.rb
+++ b/app/services/grow_zone_service.rb
@@ -1,0 +1,17 @@
+class GrowZoneService
+  def self.get_zone(zipcode)
+    response = conn.get("zipcodes/#{zipcode}")
+    parse_json(response)
+  end
+
+  def self.conn
+    Faraday.new(
+      url: 'https://plant-hardiness-zone.p.rapidapi.com',
+      headers: { 'X-RapidAPI-Key': ENV['X-RapidAPI-Key'] }
+    )
+  end
+
+  def self.parse_json(response)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/spec/facades/grow_zone_facade_spec.rb
+++ b/spec/facades/grow_zone_facade_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe GrowZoneFacade, type: :facade do
+  context 'class methods' do
+    it '#get_zone(zipcode)', :vcr do
+      expect(GrowZoneFacade.get_zone(80218)).to eq("5b")
+    end
+  end
+end

--- a/spec/poros/grow_zone_spec.rb
+++ b/spec/poros/grow_zone_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe GrowZone, type: :poro do
+  context 'attributes' do
+    it 'initializes with attributes' do
+      json = {:hardiness_zone=>"5b", :zipcode=>"80218"}
+      grow_zone = GrowZone.new(json)
+
+      expect(grow_zone).to be_a(GrowZone)
+      expect(grow_zone.zone).to eq("5b")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,6 +3,14 @@ require 'spec_helper'
 require 'simplecov'
 SimpleCov.start
 
+require 'vcr'
+VCR.configure do |c|
+  c.cassette_library_dir = 'spec/vcr'
+  c.filter_sensitive_data('rapidAPI>') { ENV['rapidAPI'] }
+  c.hook_into :webmock
+  c.configure_rspec_metadata!
+end
+
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'
 # Prevent database truncation if the environment is production

--- a/spec/services/grow_zone_service_spec.rb
+++ b/spec/services/grow_zone_service_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe GrowZoneService, type: :service do
   context 'class methods' do
-    it 'returns a grow zone from supplied zipcode' do
+    it 'returns a grow zone from supplied zipcode', :vcr do
       zipcode = '80218'
       service = GrowZoneService.get_zone(zipcode)
 

--- a/spec/services/grow_zone_service_spec.rb
+++ b/spec/services/grow_zone_service_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe GrowZoneService, type: :service do
+  context 'class methods' do
+    it 'returns a grow zone from supplied zipcode' do
+      zipcode = '80218'
+      service = GrowZoneService.get_zone(zipcode)
+
+      expect(service).to be_a(Hash)
+      expect(service).to have_key(:activity)
+      expect(service[:activity]).to be_a(String)
+    end
+  end
+end

--- a/spec/services/grow_zone_service_spec.rb
+++ b/spec/services/grow_zone_service_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe GrowZoneService, type: :service do
       service = GrowZoneService.get_zone(zipcode)
 
       expect(service).to be_a(Hash)
-      expect(service).to have_key(:activity)
-      expect(service[:activity]).to be_a(String)
+      expect(service).to have_key(:hardiness_zone)
+      expect(service[:hardiness_zone]).to be_a(String)
+      expect(service).to have_key(:zipcode)
+      expect(service[:zipcode]).to be_a(String)
     end
   end
 end

--- a/spec/vcr/GrowZoneFacade/class_methods/_get_zone_zipcode_.yml
+++ b/spec/vcr/GrowZoneFacade/class_methods/_get_zone_zipcode_.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://plant-hardiness-zone.p.rapidapi.com/zipcodes/80218
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Rapidapi-Key:
+      - rapidAPI>
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 27 Mar 2023 20:38:35 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Ratelimit-Requests-Limit:
+      - '150'
+      X-Ratelimit-Requests-Remaining:
+      - '142'
+      X-Ratelimit-Requests-Reset:
+      - '2668113'
+      Server:
+      - RapidAPI-1.2.8
+      X-Rapidapi-Version:
+      - 1.2.8
+      X-Rapidapi-Region:
+      - AWS - us-west-2
+    body:
+      encoding: UTF-8
+      string: '{"hardiness_zone":"5b","zipcode":"80218"}'
+  recorded_at: Mon, 27 Mar 2023 20:38:35 GMT
+recorded_with: VCR 6.1.0

--- a/spec/vcr/GrowZoneService/class_methods/returns_a_grow_zone_from_supplied_zipcode.yml
+++ b/spec/vcr/GrowZoneService/class_methods/returns_a_grow_zone_from_supplied_zipcode.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://plant-hardiness-zone.p.rapidapi.com/zipcodes/80218
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Rapidapi-Key:
+      - rapidAPI>
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 27 Mar 2023 20:38:36 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '41'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Ratelimit-Requests-Limit:
+      - '150'
+      X-Ratelimit-Requests-Remaining:
+      - '141'
+      X-Ratelimit-Requests-Reset:
+      - '2668112'
+      Server:
+      - RapidAPI-1.2.8
+      X-Rapidapi-Version:
+      - 1.2.8
+      X-Rapidapi-Region:
+      - AWS - us-west-2
+    body:
+      encoding: UTF-8
+      string: '{"hardiness_zone":"5b","zipcode":"80218"}'
+  recorded_at: Mon, 27 Mar 2023 20:38:36 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
# Description
## Overall
 - 🤝 Establish API connection to external [Grow Zone service ](https://plant-hardiness-zone.p.rapidapi.com/zipcodes/)
 - 📼 Implement VCR to mock our API response.
## Service 
 - 🪄 Creates files and associated test for `app/services/grow_zone_service.rb`
 - 🚨 NOTE: api-key is held in the `application.yml` file as `rapidAPI`, this is not pushed to GH for security
## Facade
 - 🪄 Creates files and associated test for `app/facades/grow_zone_facade.rb`
## Poro
 - 🪄 Creates files and associated test for `app/poros/grow_zone.rb`
 - 🤔 Unsure if Poros is needed, but one was created for future convenience.
 
Closes #19
19 "Establish Grow Zone Service"

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

`spec/services/grow_zone_service_spec.rb` created

- [x] GrowZoneService class method `self.get_zone` returns a grow zone from a supplied zipcode. 
- [ ] See CircleCI