### PR TITLE
26 be cache rapidapi response

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -14,7 +14,7 @@ module Types
 
     def vegetables_by_zipcode(args)
       zone = get_grow_zone(args)
-      require 'pry'; binding.pry
+
       {
         grow_zone: zone,
         vegetables: Vegetable.all

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -7,19 +7,26 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
     field :vegetables_by_zipcode, Types::ZipcodeResultType, null: false do
       description 'Returns a zone and basic vegetable details'
       argument :zipcode, String, required: true
     end
 
     def vegetables_by_zipcode(args)
-      zone = GrowZoneFacade.get_zone(args[:zipcode])
-
+      zone = get_grow_zone(args)
+      require 'pry'; binding.pry
       {
-        grow_zone: zone, # temp while service is built
+        grow_zone: zone,
         vegetables: Vegetable.all
       }
+    end
+
+    private
+
+    def get_grow_zone(args)
+      Rails.cache.fetch("grow_zone_query-#{args[:zipcode]}", expires_in: 24.hours) do
+        GrowZoneFacade.get_zone(args[:zipcode])
+      end
     end
   end
 end

--- a/spec/vcr/vegetables_by_zipcode/returns_a_list_of_growing_zone_and_vegetables_by_zipcode.yml
+++ b/spec/vcr/vegetables_by_zipcode/returns_a_list_of_growing_zone_and_vegetables_by_zipcode.yml
@@ -21,7 +21,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 27 Mar 2023 21:29:30 GMT
+      - Wed, 29 Mar 2023 15:32:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Content-Length:
@@ -37,9 +37,9 @@ http_interactions:
       X-Ratelimit-Requests-Limit:
       - '150'
       X-Ratelimit-Requests-Remaining:
-      - '111'
+      - '109'
       X-Ratelimit-Requests-Reset:
-      - '2233487'
+      - '2082085'
       Server:
       - RapidAPI-1.2.8
       X-Rapidapi-Version:
@@ -49,5 +49,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"hardiness_zone":"6a","zipcode":"80817"}'
-  recorded_at: Mon, 27 Mar 2023 21:29:30 GMT
+  recorded_at: Wed, 29 Mar 2023 15:32:52 GMT
 recorded_with: VCR 6.1.0


### PR DESCRIPTION
# Description

The response from RapidAPI should be cached to minimize outgoing call to the GrowZone API

This PR adds low level cacheing of the response based on the provided zipcode that expires within 24 hours. This can be adjusted for longer persistance.

closes #26 