### PR TITLE
53 be sadpath bad zipcode

### DIFF
--- a/app/errors/grow_zone_error.rb
+++ b/app/errors/grow_zone_error.rb
@@ -1,0 +1,1 @@
+class GrowZoneError < StandardError; end

--- a/app/facades/grow_zone_facade.rb
+++ b/app/facades/grow_zone_facade.rb
@@ -1,6 +1,9 @@
 class GrowZoneFacade
   def self.get_zone(zipcode)
     json = GrowZoneService.get_zone(zipcode)
+
+    raise GrowZoneError if json.nil?
+
     json_to_poro(json).zone
   end
 

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,7 @@ module Types
       description 'return details about a specific user'
       argument :user_id, String, required: true
     end
-    
+
     field :vegetables_by_zipcode, Types::ZipcodeResultType, null: false do
       description 'Returns a zone and basic vegetable details'
       argument :zipcode, String, required: true
@@ -24,7 +24,7 @@ module Types
 
     def user_details(args)
       User.find(args[:user_id])
-      rescue ActiveRecord::RecordNotFound => e
+    rescue ActiveRecord::RecordNotFound => e
       GraphQL::ExecutionError.new("Invalid input: #{e}")
     end
 
@@ -35,11 +35,13 @@ module Types
         grow_zone: zone,
         vegetables: Vegetable.all
       }
+    rescue GrowZoneError
+      GraphQL::ExecutionError.new('Zipcode returned no result')
     end
 
     def vegetable_details(args)
       Vegetable.find(args[:vegetable_id])
-      rescue ActiveRecord::RecordNotFound => e
+    rescue ActiveRecord::RecordNotFound => e
       GraphQL::ExecutionError.new("Invalid input: #{e}")
     end
 

--- a/spec/requests/vegetables_by_zipcode_spec.rb
+++ b/spec/requests/vegetables_by_zipcode_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe 'vegetables_by_zipcode', type: :request do
     expect(veggies[:data][:vegetablesByZipcode][:vegetables][1][:image]).to eq('tomato.jpg')
   end
 
+  it 'gracefully handles a bad zipcode', :vcr do
+    zip_query = query_vegetables_by_zipcode('1')
+
+    expect(zip_query).to have_key(:errors)
+    expect(zip_query[:errors][0][:message]).to eq('Zipcode returned no result')
+  end
+
   private
 
   def query_vegetables_by_zipcode(zipcode)

--- a/spec/vcr/vegetables_by_zipcode/gracefully_handles_a_bad_zipcode.yml
+++ b/spec/vcr/vegetables_by_zipcode/gracefully_handles_a_bad_zipcode.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://plant-hardiness-zone.p.rapidapi.com/zipcodes/1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      X-Rapidapi-Key:
+      - rapidAPI>
+      User-Agent:
+      - Faraday v2.7.4
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 05 Apr 2023 21:03:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '4'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31556926; includeSubDomains; preload
+      Access-Control-Allow-Origin:
+      - "*"
+      X-Ratelimit-Requests-Limit:
+      - '150'
+      X-Ratelimit-Requests-Remaining:
+      - '69'
+      X-Ratelimit-Requests-Reset:
+      - '1457439'
+      Server:
+      - RapidAPI-1.2.8
+      X-Rapidapi-Version:
+      - 1.2.8
+      X-Rapidapi-Region:
+      - AWS - us-east-1
+    body:
+      encoding: UTF-8
+      string: 'null'
+  recorded_at: Wed, 05 Apr 2023 21:03:38 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
# Description
This is to gracefully handle a bad zipcode causing a null return from the grow zone api.

Fixes #53 

## Type of Change
- creates a custom error in app/errors
- updates the grow_zone_facade to raise the custom error
- updates the vegetables_by_zipcode resolver method to rescue from the new error
- adds test and vcr file for error message

# How Has This Been Tested?
Rspec sad path test

## Requested Reviewer(s)
J, Lacey